### PR TITLE
invalidate nickname cache when the nickname is set

### DIFF
--- a/src/main/java/eu/pb4/stylednicknames/NicknameCache.java
+++ b/src/main/java/eu/pb4/stylednicknames/NicknameCache.java
@@ -1,0 +1,5 @@
+package eu.pb4.stylednicknames;
+
+public interface NicknameCache {
+    void styledNicknames$invalidateCache();
+}

--- a/src/main/java/eu/pb4/stylednicknames/NicknameHolder.java
+++ b/src/main/java/eu/pb4/stylednicknames/NicknameHolder.java
@@ -88,17 +88,4 @@ public interface NicknameHolder {
     boolean styledNicknames$shouldDisplay();
 
     Map<String, Text> styledNicknames$placeholdersCommand();
-
-
-    // Kept for switchy so it won't break
-    @Deprecated
-    default String sn_get() {
-        return this.styledNicknames$get();
-    }
-
-    // Kept for switchy so it won't break
-    @Deprecated
-    default void sn_set(String input, boolean permission) {
-        this.styledNicknames$set(input, permission);
-    }
 }

--- a/src/main/java/eu/pb4/stylednicknames/mixin/PlayerEntityMixin.java
+++ b/src/main/java/eu/pb4/stylednicknames/mixin/PlayerEntityMixin.java
@@ -1,6 +1,7 @@
 package eu.pb4.stylednicknames.mixin;
 
 import eu.pb4.stylednicknames.NicknameHolder;
+import eu.pb4.stylednicknames.NicknameCache;
 import eu.pb4.stylednicknames.config.ConfigManager;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -14,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 
 @Mixin(PlayerEntity.class)
-public abstract class PlayerEntityMixin extends LivingEntity {
+public abstract class PlayerEntityMixin extends LivingEntity implements NicknameCache {
     @Unique private boolean styledNicknames$ignoreNextCall = false;
     @Unique private Text styledNicknames$cachedName = null;
     @Unique private int styledNicknames$cachedAge = -999;
@@ -52,4 +53,9 @@ public abstract class PlayerEntityMixin extends LivingEntity {
         return text;
     }
 
+    @Override
+    public void styledNicknames$invalidateCache() {
+        this.styledNicknames$cachedName = null;
+        this.styledNicknames$cachedAge = - 999;
+    }
 }

--- a/src/main/java/eu/pb4/stylednicknames/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/eu/pb4/stylednicknames/mixin/ServerPlayNetworkHandlerMixin.java
@@ -4,6 +4,7 @@ import eu.pb4.placeholders.api.Placeholders;
 import eu.pb4.placeholders.api.TextParserUtils;
 import eu.pb4.placeholders.api.parsers.TextParserV1;
 import eu.pb4.playerdata.api.PlayerDataApi;
+import eu.pb4.stylednicknames.NicknameCache;
 import eu.pb4.stylednicknames.NicknameHolder;
 import eu.pb4.stylednicknames.config.Config;
 import eu.pb4.stylednicknames.config.ConfigManager;
@@ -101,6 +102,7 @@ public class ServerPlayNetworkHandlerMixin implements NicknameHolder {
         if (config.configData.changePlayerListName) {
             Objects.requireNonNull(this.player.getServer()).getPlayerManager().sendToAll(new PlayerListS2CPacket(PlayerListS2CPacket.Action.UPDATE_DISPLAY_NAME, this.player));
         }
+        ((NicknameCache) this.player).styledNicknames$invalidateCache();
     }
 
     @Override


### PR DESCRIPTION
prevents old nicknames appearing if they're written and read in the same tick

I also removed the sn_set and sn_get methods left in for switchy - switchy 1.19.3 onward uses the new methods so this is overdue.