### PR TITLE
Implement check for spaces in nicknames and a configuration to disable that check

### DIFF
--- a/src/main/java/eu/pb4/stylednicknames/command/Commands.java
+++ b/src/main/java/eu/pb4/stylednicknames/command/Commands.java
@@ -102,6 +102,12 @@ public class Commands {
             }
         }
 
+        if(nickname.contains(" ") && !config.configData.allowSpacesInNicknames){
+            context.getSource().sendFeedback(() -> config.nicknameCantContainSpacesText, false);
+            return 1;
+        }
+
+
         holder.styledNicknames$set(nickname, true);
         context.getSource().sendFeedback(() ->
                         ConfigManager.getConfig().changeText.toText(ParserContext.of(Config.KEY, holder.styledNicknames$placeholdersCommand())),

--- a/src/main/java/eu/pb4/stylednicknames/config/Config.java
+++ b/src/main/java/eu/pb4/stylednicknames/config/Config.java
@@ -32,6 +32,7 @@ public final class Config {
     public final TextNode changeText;
     public final TextNode resetText;
     public final Text tooLongText;
+    public final Text nicknameCantContainSpacesText;
 
     public Config(ConfigData data) {
         this.configData = data;
@@ -40,6 +41,7 @@ public final class Config {
         this.changeText = PARSER.parseNode(data.nicknameChangedMessage);
         this.resetText = PARSER.parseNode(data.nicknameResetMessage);
         this.tooLongText = PARSER.parseText(data.tooLongMessage, ParserContext.of());
+        this.nicknameCantContainSpacesText = PARSER.parseText(data.nicknameCantContainSpacesMessage, ParserContext.of());
         this.defaultFormattingCodes = new Object2BooleanArrayMap<>(this.configData.defaultEnabledFormatting);
     }
 

--- a/src/main/java/eu/pb4/stylednicknames/config/data/ConfigData.java
+++ b/src/main/java/eu/pb4/stylednicknames/config/data/ConfigData.java
@@ -22,6 +22,8 @@ public class ConfigData {
     public String nicknameResetMessage = "Your nickname has been removed!";
     public HashMap<String, Boolean> defaultEnabledFormatting = getDefaultFormatting();
     public String tooLongMessage = "This nickname is too long!";
+    public boolean allowSpacesInNicknames = false;
+    public String nicknameCantContainSpacesMessage = "Nickname can't contain spaces!";
 
     private static HashMap<String, Boolean> getDefaultFormatting() {
         HashMap<String, Boolean> map = new HashMap<>();


### PR DESCRIPTION
# Description
As the title says. Fix for issue #28 

The first commit is a fast implementation, later tonight ill check if something needs polishing.

# Configuration changes
Added the following configuration lines
```json
  "allowSpacesInNicknames": false,
  "nicknameCantContainSpacesMessage": "Nickname can't contain spaces!"
```

# Post scriptum
Love the plugin. Helped me port a 800+ member server to fabric after 8 years of dreaming to do so.