### PR TITLE
add playername placeholder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ tasks.withType(JavaCompile).configureEach {
 
 	// Minecraft 1.17 (21w19a) upwards uses Java 16.
 	it.options.release = 25
+	options.compilerArgs << "-Xlint:deprecation"
 }
 
 java {

--- a/src/main/java/eu/pb4/stylednicknames/command/Commands.java
+++ b/src/main/java/eu/pb4/stylednicknames/command/Commands.java
@@ -116,12 +116,24 @@ public class Commands {
         return 0;
     }
 
-    private static int reset(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
-        NicknameHolder.of(context.getSource().getPlayerOrException()).styledNicknames$set(null, false);
-        context.getSource().sendSuccess(() ->
-                        ConfigManager.getConfig().resetText.toComponent(ParserContext.of(Config.KEY, (x) -> context.getSource().getPlayer().getName()
-                        )),
-                false);
+    private static int reset(CommandContext<CommandSourceStack> context)
+        throws CommandSyntaxException {
+        var holder = NicknameHolder.of(
+            context.getSource().getPlayerOrException()
+        );
+        holder.styledNicknames$set(null, false);
+        context
+            .getSource()
+            .sendSuccess(
+                () ->
+                    ConfigManager.getConfig().resetText.toComponent(
+                        ParserContext.of(
+                            Config.KEY,
+                            holder.styledNicknames$placeholdersCommand()
+                        )
+                    ),
+                false
+            );
         return 0;
     }
 

--- a/src/main/java/eu/pb4/stylednicknames/config/ConfigManager.java
+++ b/src/main/java/eu/pb4/stylednicknames/config/ConfigManager.java
@@ -2,6 +2,7 @@ package eu.pb4.stylednicknames.config;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
 import eu.pb4.stylednicknames.StyledNicknamesMod;
 import eu.pb4.stylednicknames.config.data.ConfigData;
 import eu.pb4.stylednicknames.config.data.VersionConfigData;
@@ -9,15 +10,29 @@ import net.fabricmc.loader.api.FabricLoader;
 import org.apache.commons.io.IOUtils;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 public class ConfigManager {
     public static final int VERSION = 2;
-    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().setLenient().create();
+
+    // Removed .setLenient() – builder is no longer globally lenient
+    private static final Gson GSON = new GsonBuilder()
+            .setPrettyPrinting()
+            .disableHtmlEscaping()
+            .create();
 
     private static Config CONFIG;
 
     public static Config getConfig() {
         return CONFIG;
+    }
+
+    // Helper method: enables lenient mode only for parsing operations
+    private static <T> T fromJsonLenient(String json, Class<T> classOfT) throws IOException {
+        try (JsonReader reader = new JsonReader(new StringReader(json))) {
+            reader.setLenient(true);
+            return GSON.fromJson(reader, classOfT);
+        }
     }
 
     public static boolean loadConfig() {
@@ -28,20 +43,23 @@ public class ConfigManager {
 
 
             if (configFile.exists()) {
-                String json = IOUtils.toString(new InputStreamReader(new FileInputStream(configFile), "UTF-8"));
-                VersionConfigData versionConfigData = GSON.fromJson(json, VersionConfigData.class);
+                String json = IOUtils.toString(new InputStreamReader(new FileInputStream(configFile), StandardCharsets.UTF_8));
+
+                // Use lenient helper here
+                VersionConfigData versionConfigData = fromJsonLenient(json, VersionConfigData.class);
 
                 config = ConfigData.transform(switch (versionConfigData.CONFIG_VERSION_DONT_TOUCH_THIS) {
-                    default -> GSON.fromJson(json, ConfigData.class);
+                    default -> fromJsonLenient(json, ConfigData.class); // Use lenient helper here too
                 });
             } else {
                 config = new ConfigData();
             }
 
-            BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(configFile), "UTF-8"));
-            writer.write(GSON.toJson(config));
-            writer.close();
-
+            // Writing doesn't need leniency – keep as is
+            try (BufferedWriter writer = new BufferedWriter(
+                    new OutputStreamWriter(new FileOutputStream(configFile), StandardCharsets.UTF_8))) {
+                writer.write(GSON.toJson(config));
+            }
 
             CONFIG = new Config(config);
             return true;

--- a/src/main/java/eu/pb4/stylednicknames/mixin/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/eu/pb4/stylednicknames/mixin/ServerGamePacketListenerImplMixin.java
@@ -1,5 +1,7 @@
 package eu.pb4.stylednicknames.mixin;
 
+import static eu.pb4.stylednicknames.StyledNicknamesMod.id;
+
 import eu.pb4.placeholders.api.ParserContext;
 import eu.pb4.playerdata.api.PlayerDataApi;
 import eu.pb4.stylednicknames.FabricPermissionBridge;
@@ -8,6 +10,9 @@ import eu.pb4.stylednicknames.NicknameHolder;
 import eu.pb4.stylednicknames.ParserUtils;
 import eu.pb4.stylednicknames.config.Config;
 import eu.pb4.stylednicknames.config.ConfigManager;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.function.Function;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.nbt.ByteTag;
 import net.minecraft.nbt.StringTag;
@@ -22,34 +27,43 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 
-import java.util.Locale;
-import java.util.Objects;
-import java.util.function.Function;
-
-import static eu.pb4.stylednicknames.StyledNicknamesMod.id;
-
-
 @Mixin(ServerGamePacketListenerImpl.class)
 public class ServerGamePacketListenerImplMixin implements NicknameHolder {
+
     @Shadow
     public ServerPlayer player;
+
     @Unique
     private String styledNicknames$nickname = null;
+
     @Unique
     private Component styledNicknames$parsedNicknameRaw = null;
+
     @Unique
     private boolean colorOnlyMode = false;
+
     @Unique
     private boolean styledNicknames$requirePermission = true;
 
     @Override
     public void styledNicknames$loadData() {
         try {
-            StringTag nickname = PlayerDataApi.getGlobalDataFor(player, id("nickname"), StringTag.TYPE);
-            ByteTag permissions = PlayerDataApi.getGlobalDataFor(player, id("permission"), ByteTag.TYPE);
+            StringTag nickname = PlayerDataApi.getGlobalDataFor(
+                player,
+                id("nickname"),
+                StringTag.TYPE
+            );
+            ByteTag permissions = PlayerDataApi.getGlobalDataFor(
+                player,
+                id("permission"),
+                ByteTag.TYPE
+            );
 
             if (nickname != null) {
-                this.styledNicknames$set(nickname.value(),  permissions != null && permissions.byteValue() > 0);
+                this.styledNicknames$set(
+                    nickname.value(),
+                    permissions != null && permissions.byteValue() > 0
+                );
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -57,30 +71,69 @@ public class ServerGamePacketListenerImplMixin implements NicknameHolder {
     }
 
     @Override
-    public void styledNicknames$set(String nickname, boolean requirePermission) {
+    public void styledNicknames$set(
+        String nickname,
+        boolean requirePermission
+    ) {
         Config config = ConfigManager.getConfig();
         CommandSourceStack source = player.createCommandSourceStack();
-        if (nickname == null || nickname.isEmpty() || (requirePermission && !FabricPermissionBridge.checkPermission(player, id("use"), ConfigManager.getConfig().configData.allowByDefault ? PermissionLevel.ALL : PermissionLevel.GAMEMASTERS))) {
+        if (
+            nickname == null ||
+            nickname.isEmpty() ||
+            (requirePermission &&
+                !FabricPermissionBridge.checkPermission(
+                    player,
+                    id("use"),
+                    ConfigManager.getConfig().configData.allowByDefault
+                        ? PermissionLevel.ALL
+                        : PermissionLevel.GAMEMASTERS
+                ))
+        ) {
             this.styledNicknames$nickname = null;
             this.styledNicknames$requirePermission = false;
             this.styledNicknames$parsedNicknameRaw = null;
             PlayerDataApi.setGlobalDataFor(this.player, id("nickname"), null);
-            PlayerDataApi.setGlobalDataFor(this.player, id("permission"), ByteTag.valueOf(false));
+            PlayerDataApi.setGlobalDataFor(
+                this.player,
+                id("permission"),
+                ByteTag.valueOf(false)
+            );
         } else {
             this.styledNicknames$nickname = nickname;
             this.styledNicknames$requirePermission = requirePermission;
-            PlayerDataApi.setGlobalDataFor(this.player, id("nickname"), StringTag.valueOf(nickname));
-            PlayerDataApi.setGlobalDataFor(this.player, id("permission"), ByteTag.valueOf(requirePermission));
+            PlayerDataApi.setGlobalDataFor(
+                this.player,
+                id("nickname"),
+                StringTag.valueOf(nickname)
+            );
+            PlayerDataApi.setGlobalDataFor(
+                this.player,
+                id("permission"),
+                ByteTag.valueOf(requirePermission)
+            );
 
-            var text = ParserUtils.getParser(requirePermission ? this.player : null)
-                    .parseComponent(nickname, ParserContext.of());
+            var text = ParserUtils.getParser(
+                requirePermission ? this.player : null
+            ).parseComponent(nickname, ParserContext.of());
 
-            this.colorOnlyMode = text.getString().toLowerCase(Locale.ROOT).equals(this.player.getGameProfile().name().toLowerCase(Locale.ROOT));
+            this.colorOnlyMode = text
+                .getString()
+                .toLowerCase(Locale.ROOT)
+                .equals(
+                    this.player.getGameProfile().name().toLowerCase(Locale.ROOT)
+                );
             this.styledNicknames$parsedNicknameRaw = text;
         }
 
         if (config.configData.changePlayerListName) {
-            Objects.requireNonNull(this.player.level().getServer()).getPlayerList().broadcastAll(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME, this.player));
+            Objects.requireNonNull(this.player.level().getServer())
+                .getPlayerList()
+                .broadcastAll(
+                    new ClientboundPlayerInfoUpdatePacket(
+                        ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME,
+                        this.player
+                    )
+                );
         }
         ((NicknameCache) this.player).styledNicknames$invalidateCache();
     }
@@ -98,15 +151,36 @@ public class ServerGamePacketListenerImplMixin implements NicknameHolder {
     @Override
     public @Nullable MutableComponent styledNicknames$getOutput() {
         return this.styledNicknames$parsedNicknameRaw != null
-                ? (this.colorOnlyMode ? ConfigManager.getConfig().nicknameFormatColor : ConfigManager.getConfig().nicknameFormat)
-                .toComponent(ParserContext.of(Config.KEY, (s) -> this.styledNicknames$parsedNicknameRaw)).copy() : null;
+            ? (this.colorOnlyMode
+                  ? ConfigManager.getConfig().nicknameFormatColor
+                  : ConfigManager.getConfig().nicknameFormat
+              )
+                  .toComponent(
+                      ParserContext.of(
+                          Config.KEY,
+                          this::styledNicknames$placeholderResolver
+                      )
+                  )
+                  .copy()
+            : null;
     }
 
     @Override
     public MutableComponent styledNicknames$getOutputOrVanilla() {
         return this.styledNicknames$parsedNicknameRaw != null
-                ? (this.colorOnlyMode ? ConfigManager.getConfig().nicknameFormatColor : ConfigManager.getConfig().nicknameFormat)
-                .toComponent(ParserContext.of(Config.KEY, (s) -> this.styledNicknames$parsedNicknameRaw)).copy() : this.player.getName().copy();    }
+            ? (this.colorOnlyMode
+                  ? ConfigManager.getConfig().nicknameFormatColor
+                  : ConfigManager.getConfig().nicknameFormat
+              )
+                  .toComponent(
+                      ParserContext.of(
+                          Config.KEY,
+                          this::styledNicknames$placeholderResolver
+                      )
+                  )
+                  .copy()
+            : this.player.getName().copy();
+    }
 
     @Override
     public boolean styledNicknames$requiresPermission() {
@@ -115,12 +189,34 @@ public class ServerGamePacketListenerImplMixin implements NicknameHolder {
 
     @Override
     public boolean styledNicknames$shouldDisplay() {
-        return this.styledNicknames$parsedNicknameRaw != null && (!this.styledNicknames$requirePermission || FabricPermissionBridge.checkPermission(player, id("use"), ConfigManager.getConfig().configData.allowByDefault ? PermissionLevel.ALL : PermissionLevel.GAMEMASTERS));
+        return (
+            this.styledNicknames$parsedNicknameRaw != null &&
+            (!this.styledNicknames$requirePermission ||
+                FabricPermissionBridge.checkPermission(
+                    player,
+                    id("use"),
+                    ConfigManager.getConfig().configData.allowByDefault
+                        ? PermissionLevel.ALL
+                        : PermissionLevel.GAMEMASTERS
+                ))
+        );
     }
 
     @Override
     public Function<String, Component> styledNicknames$placeholdersCommand() {
-        var name = this.styledNicknames$getOutputOrVanilla();
-        return x -> name;
+        return this::styledNicknames$placeholderResolver;
+    }
+
+    @Unique
+    private Component styledNicknames$placeholderResolver(String key) {
+        if ("playername".equals(key)) {
+            return Component.literal(this.player.getGameProfile().name());
+        }
+        if ("nickname".equals(key)) {
+            return this.styledNicknames$parsedNicknameRaw != null
+                ? this.styledNicknames$parsedNicknameRaw.copy()
+                : Component.empty();
+        }
+        return Component.empty();
     }
 }


### PR DESCRIPTION
currently, the upstream has really few placeholders for display name. i wanted to make it to display real unmodified playername, so i can manage players easily with tools that does not integrate with Styled Nicknames.
# features of PR
## player name display
now the config can use ${playername} to return unmodified player name.
example config:
```
"nicknameFormat": "${nickname}#${playername}"
```
## remove deprecated GSON method
`GsonBuilder.setLenient()` is deprecated and should not be used.
this PR fixes that by importing `import com.google.gson.stream.JsonReader`.

## remove unclear string literal
use `StandardCharsets.UTF_8` instead of `UTF-8` string

## display deprecation while building
you can just omit this change if you unlike it.
